### PR TITLE
Configurazione Coveralls per Code Coverage nella pipeline CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,19 +27,7 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      # Step 3: Compilazione del progetto (fase compile)
-      - name: Compilazione
-        run: mvn compile --file roman-number/pom.xml
-
-      # Step 4: Esecuzione dei test (fase test)
-      - name: Esecuzione Test
-        run: mvn test --file roman-number/pom.xml
-
-      # Step 5: Analisi statica e package
+      # Step 3: compile-test-checkstyle-package lifecycle
       - name: Build completa
-        run: mvn verify --file roman-number/pom.xml
-
-      - name: Upload Coveralls
-        run: mvn coveralls:report
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        working-directory: roman-number
+        run: mvn verify

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,4 +1,4 @@
-# Pipeline di Continuous Integration per il progetto Roman Number
+# Pipeline di Continuous Integration
 # Si attiva ad ogni push e ad ogni Pull Request
 
 name: Continuous Integration
@@ -27,7 +27,21 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      # Step 3: compile-test-checkstyle-package lifecycle
-      - name: Build completa
-        working-directory: roman-number
-        run: mvn verify
+      # Step 3: Compilazione del progetto (fase compile)
+      - name: Compilazione
+        run: mvn compile --file roman-number/pom.xml
+
+      # Step 4: Esecuzione dei test (fase test)
+      - name: Esecuzione Test
+        run: mvn test --file roman-number/pom.xml
+
+      # Step 5: Analisi statica e package
+      - name: Analisi Statica e Package
+        run: mvn package --file roman-number/pom.xml
+
+        # Step 6: Invio coverage a Coveralls
+      - name: Invio Coverage a Coveralls
+        run: mvn coveralls:report --file roman-number/pom.xml
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        continue-on-error: true

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,5 +36,5 @@ jobs:
         run: mvn test --file roman-number/pom.xml
 
       # Step 5: Analisi statica e package
-      - name: Analisi Statica e Package
-        run: mvn package --file roman-number/pom.xml
+      - name: Build completa
+        run: mvn verify --file roman-number/pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -38,3 +38,8 @@ jobs:
       # Step 5: Analisi statica e package
       - name: Build completa
         run: mvn verify --file roman-number/pom.xml
+
+      - name: Upload Coveralls
+        run: mvn coveralls:report
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/roman-number/checkstyle.xml
+++ b/roman-number/checkstyle.xml
@@ -4,7 +4,7 @@
 <module name="Checker">
     <!-- Controllo su header -->
     <module name="Header">
-    <property name="headerFile" value="header.txt"/>
+    <property name="headerFile" value="${basedir}/header.txt"/>
     </module>
 
     <module name="FileLength">

--- a/roman-number/checkstyle.xml
+++ b/roman-number/checkstyle.xml
@@ -4,7 +4,7 @@
 <module name="Checker">
     <!-- Controllo su header -->
     <module name="Header">
-    <property name="headerFile" value="${basedir}/header.txt"/>
+    <property name="headerFile" value="header.txt"/>
     </module>
 
     <module name="FileLength">

--- a/roman-number/pom.xml
+++ b/roman-number/pom.xml
@@ -41,7 +41,7 @@
             <execution>
                 <phase>verify</phase>
                 <goals>
-                    <goal>checkstyle</goal>
+                    <goal>check</goal>
                 </goals>
             </execution>
         </executions>

--- a/roman-number/pom.xml
+++ b/roman-number/pom.xml
@@ -46,6 +46,30 @@
             </execution>
         </executions>
       </plugin>
+      <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.8.8</version>
+
+          <executions>
+              <!-- Attiva agent per raccogliere coverage -->
+              <execution>
+                  <id>prepare-agent</id>
+                  <goals>
+                      <goal>prepare-agent</goal>
+                  </goals>
+              </execution>
+
+               <!-- Genera report dopo i test -->
+              <execution>
+                  <id>report</id>
+                  <phase>test</phase>
+                  <goals>
+                      <goal>report</goal>
+                  </goals>
+              </execution>
+          </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/roman-number/pom.xml
+++ b/roman-number/pom.xml
@@ -70,6 +70,16 @@
               </execution>
           </executions>
       </plugin>
+      <plugin>
+        <groupId>org.eluder.coveralls</groupId>
+        <artifactId>coveralls-maven-plugin</artifactId>
+        <version>4.3.0</version>
+        <configuration>
+            <jacocoReports>
+                <jacocoReport>target/site/jacoco/jacoco.xml</jacocoReport>
+            </jacocoReports>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/roman-number/src/test/java/it/unipd/mtss/IntegerToRomanTest.java
+++ b/roman-number/src/test/java/it/unipd/mtss/IntegerToRomanTest.java
@@ -17,6 +17,13 @@ public class IntegerToRomanTest {
     }
 
     @Test
+    public void convertTest0() {
+        IntegerToRoman integer = new IntegerToRoman();
+        String t = IntegerToRoman.convert(4);
+        assertEquals("IV", t);
+    }
+
+    @Test
     public void converTest2(){
         IntegerToRoman integer = new IntegerToRoman();
         String t = IntegerToRoman.convert(5);


### PR DESCRIPTION
Aggiornato il file `.github/workflows/maven.yml` per includere il plugin di Coveralls.
Configurato l'invio automatico dei report di Code Coverage dopo l'esecuzione dei test (`mvn test`).

Questa automazione ci permette di avere il controllo continuo sulla percentuale di codice testato ad ogni nuova modifica.

Chiude definitivamente #11 e conclude anche #12