### PR TITLE
Fix  Coveralls Token

### DIFF
--- a/roman-number/pom.xml
+++ b/roman-number/pom.xml
@@ -97,6 +97,7 @@
         <artifactId>coveralls-maven-plugin</artifactId>
         <version>4.3.0</version>
         <configuration>
+            <repoToken>${env.COVERALLS_REPO_TOKEN}</repoToken>
             <jacocoReports>
                 <jacocoReport>target/site/jacoco/jacoco.xml</jacocoReport>
             </jacocoReports>


### PR DESCRIPTION
Aggiunto repoToken nel pom.xml per far funzionare l'invio della coverage a Coveralls. Chiude #29