### PR TITLE
Fix Coveralls - aggiunta dipendenza jaxb-api

### DIFF
--- a/roman-number/pom.xml
+++ b/roman-number/pom.xml
@@ -96,6 +96,13 @@
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>
         <version>4.3.0</version>
+        <dependencies>
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>2.3.1</version>
+            </dependency>
+        </dependencies>
         <configuration>
             <repoToken>${env.COVERALLS_REPO_TOKEN}</repoToken>
             <jacocoReports>


### PR DESCRIPTION
Fix del bug #29: aggiunta dipendenza javax.xml.bind jaxb-api al plugin 
Coveralls per compatibilità con Java 11+.

Chiude #29